### PR TITLE
Update BoyCtrl bindings for newer DLL exports

### DIFF
--- a/defs/boy_pc_reader.def
+++ b/defs/boy_pc_reader.def
@@ -12,12 +12,14 @@ EXPORTS
     BoyCtrlSetAnyKeyStopSpeaking
     BoyCtrlSpeak
     BoyCtrlSpeak2
+    BoyCtrlSpeak3
     BoyCtrlSpeakAnsi
     BoyCtrlSpeakEx
     BoyCtrlSpeakU8
     BoyCtrlStartTextToAudio
     BoyCtrlStopSpeaking
     BoyCtrlStopSpeaking2
+    BoyCtrlStopSpeaking3
     BoyCtrlStopSpeakingEx
     BoyCtrlUninitialize
     BoyCtrlVerify

--- a/defs/boy_pc_reader32.def
+++ b/defs/boy_pc_reader32.def
@@ -12,12 +12,14 @@ EXPORTS
     BoyCtrlSetAnyKeyStopSpeaking@4
     BoyCtrlSpeak@20
     BoyCtrlSpeak2@4
+    BoyCtrlSpeak3@24
     BoyCtrlSpeakAnsi@20
     BoyCtrlSpeakEx@12
     BoyCtrlSpeakU8@20
     BoyCtrlStartTextToAudio@32
     BoyCtrlStopSpeaking@4
     BoyCtrlStopSpeaking2@0
+    BoyCtrlStopSpeaking3@8
     BoyCtrlStopSpeakingEx@4
     BoyCtrlUninitialize@0
     BoyCtrlVerify@4

--- a/source/backends/raw/boy_pc_reader.h
+++ b/source/backends/raw/boy_pc_reader.h
@@ -40,6 +40,10 @@ BoyCtrlSpeak(const wchar_t *text, bool withSlave, bool append, bool allowBreak,
              BoyCtrlSpeakCompleteFunc onCompletion);
 __declspec(dllimport) BoyCtrlError __stdcall BoyCtrlSpeak2(const wchar_t *text);
 __declspec(dllimport) BoyCtrlError __stdcall
+BoyCtrlSpeak3(const wchar_t *text, bool withSlave, const wchar_t *slaveName,
+              bool append, bool allowBreak,
+              BoyCtrlSpeakCompleteFunc onCompletion);
+__declspec(dllimport) BoyCtrlError __stdcall
 BoyCtrlSpeakEx(const wchar_t *text, int flags,
                BoyCtrlSpeakCompleteFunc onCompletion);
 __declspec(dllimport) BoyCtrlError __stdcall
@@ -52,6 +56,8 @@ __declspec(dllimport) BoyCtrlError __stdcall
 BoyCtrlStopSpeaking(bool withSlave);
 __declspec(dllimport) BoyCtrlError __stdcall BoyCtrlStopSpeakingEx(int flags);
 __declspec(dllimport) BoyCtrlError __stdcall BoyCtrlStopSpeaking2();
+__declspec(dllimport) BoyCtrlError __stdcall
+BoyCtrlStopSpeaking3(bool withSlave, const wchar_t *slaveName);
 __declspec(dllimport) BoyCtrlError __stdcall BoyCtrlPauseScreenReader(int ms);
 __declspec(dllimport) void __stdcall BoyCtrlUninitialize();
 __declspec(dllimport) bool __stdcall BoyCtrlIsReaderRunning();

--- a/source/delayimp.cpp
+++ b/source/delayimp.cpp
@@ -123,6 +123,16 @@ stub_BoyCtrlSpeak2([[maybe_unused]] const wchar_t *text) {
 }
 
 static BoyCtrlError __stdcall
+stub_BoyCtrlSpeak3([[maybe_unused]] const wchar_t *text,
+                   [[maybe_unused]] bool withSlave,
+                   [[maybe_unused]] const wchar_t *slaveName,
+                   [[maybe_unused]] bool append,
+                   [[maybe_unused]] bool allowBreak,
+                   [[maybe_unused]] BoyCtrlSpeakCompleteFunc onCompletion) {
+  return e_bcerr_unavailable;
+}
+
+static BoyCtrlError __stdcall
 stub_BoyCtrlSpeakEx([[maybe_unused]] const wchar_t *text,
                     [[maybe_unused]] int flags,
                     [[maybe_unused]] BoyCtrlSpeakCompleteFunc onCompletion) {
@@ -154,6 +164,12 @@ stub_BoyCtrlStopSpeakingEx([[maybe_unused]] int flags) {
 }
 
 static BoyCtrlError __stdcall stub_BoyCtrlStopSpeaking2() {
+  return e_bcerr_unavailable;
+}
+
+static BoyCtrlError __stdcall
+stub_BoyCtrlStopSpeaking3([[maybe_unused]] bool withSlave,
+                          [[maybe_unused]] const wchar_t *slaveName) {
   return e_bcerr_unavailable;
 }
 
@@ -445,6 +461,9 @@ static const
          .func = "BoyCtrlSpeak2",
          .stub = stub_cast(boy_pc_reader::stub_BoyCtrlSpeak2)},
         {.dll = BOY_PC_READER_DLL,
+         .func = "BoyCtrlSpeak3",
+         .stub = stub_cast(boy_pc_reader::stub_BoyCtrlSpeak3)},
+        {.dll = BOY_PC_READER_DLL,
          .func = "BoyCtrlSpeakEx",
          .stub = stub_cast(boy_pc_reader::stub_BoyCtrlSpeakEx)},
         {.dll = BOY_PC_READER_DLL,
@@ -462,6 +481,9 @@ static const
         {.dll = BOY_PC_READER_DLL,
          .func = "BoyCtrlStopSpeaking2",
          .stub = stub_cast(boy_pc_reader::stub_BoyCtrlStopSpeaking2)},
+        {.dll = BOY_PC_READER_DLL,
+         .func = "BoyCtrlStopSpeaking3",
+         .stub = stub_cast(boy_pc_reader::stub_BoyCtrlStopSpeaking3)},
         {.dll = BOY_PC_READER_DLL,
          .func = "BoyCtrlPauseScreenReader",
          .stub = stub_cast(boy_pc_reader::stub_BoyCtrlPauseScreenReader)},


### PR DESCRIPTION
## Summary

- add declarations for newer BoyCtrl DLL exports used by recent BoyCtrl builds on Windows
- add matching 32-bit and 64-bit export definitions for `BoyCtrlSpeak3` and `BoyCtrlStopSpeaking3`
- add delay-load fallback stubs for those newer BoyCtrl exports

## Scope

This PR only updates the BoyCtrl Windows binding surface so newer BoyCtrl DLL exports can be resolved correctly.
It does not change BoyPCReader backend behavior, channel selection, callback handling, or runtime selection logic.

## Validation

- built Prism on Windows with `cmake --build build --config Debug --target prism --parallel 8`
- verified that the library links successfully with the updated BoyCtrl import/export definitions

## AI Assistance Disclosure

This fix was implemented with the help of OpenAI Codex and was then reviewed and validated locally before preparing this PR.
