### PR TITLE
Fix AttributeError when prism is imported on Linux

### DIFF
--- a/bindings/py/prism/prism/lib.py
+++ b/bindings/py/prism/prism/lib.py
@@ -28,7 +28,7 @@ with contextlib.suppress(AttributeError):
 
 
 def _is_android() -> bool:
-    with contextlib.suppress(ImportError):
+    with contextlib.suppress(AttributeError):
         if importlib.util.find_spec("", "android") is not None:
             return True
     if sys.platform == "linux":


### PR DESCRIPTION
When Prism's Python bindings were imported on Linux, specifically Gentoo, it caused an AttributeError. I've tracked the error to _is_android() function in lib.py. It was suppressing ImportError, but it should've been AttributeError. That has been fixed. This resolves #10. The fix was tested on the same system and it works.