### PR TITLE
Switch speech dispatcher priority to message to fix queuing of speech.

### DIFF
--- a/source/backends/speech_dispatcher.cpp
+++ b/source/backends/speech_dispatcher.cpp
@@ -160,7 +160,7 @@ public:
         return std::unexpected(BackendError::InternalBackendError);
       paused.clear();
     }
-    if (const auto res = spd_say(conn, SPD_TEXT, text.data()); res < 0) {
+    if (const auto res = spd_say(conn, SPD_MESSAGE, text.data()); res < 0) {
       return std::unexpected(BackendError::SpeakFailure);
     }
     return {};


### PR DESCRIPTION
In the speech dispatcher backend, previously it was using the spd priority text. This would cause messages to *always* interrupt each other, even when interrupt was set to false. I switched it to message as that is the priority I've found to queue speech properly.