### PR TITLE
Fix static library usage on windows by handling autogenerated import libraries on CMake install/link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ function(add_import_library target def_file dll_name)
   set_target_properties(${target} PROPERTIES IMPORTED_IMPLIB "${lib_file}"
                                              IMPORTED_LOCATION "${dll_name}")
   add_dependencies(${target} ${target}_gen)
+  list(APPEND _PRISM_WIN_IMPORT_LIBS "${target}")
+  set(_PRISM_WIN_IMPORT_LIBS "${_PRISM_WIN_IMPORT_LIBS}" PARENT_SCOPE)
 endfunction()
 function(prism_add_backend src)
   get_filename_component(name "${src}" NAME_WE)
@@ -354,6 +356,7 @@ if(_PRISM_LIB_TYPE STREQUAL "STATIC_LIBRARY")
 else()
   set(_PRISM_LINK_VIS PRIVATE)
 endif()
+set(_PRISM_WIN_IMPORT_LIBS "")
 if(WIN32)
   target_link_libraries(${PROJECT_NAME} PRIVATE delayimp.lib onecore.lib
                                                 uiautomationcore.lib)
@@ -904,6 +907,14 @@ else()
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion)
   install(DIRECTORY include/ DESTINATION include)
+  if(WIN32 AND _PRISM_LIB_TYPE STREQUAL "STATIC_LIBRARY")
+    foreach(_imp IN LISTS _PRISM_WIN_IMPORT_LIBS)
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${_imp}.lib" DESTINATION lib)
+    endforeach()
+    set(PRISM_WIN_STATIC_IMPORT_LIBS "${_PRISM_WIN_IMPORT_LIBS}")
+  else()
+    set(PRISM_WIN_STATIC_IMPORT_LIBS "")
+  endif()
   configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/prism-config.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/prism-config.cmake"

--- a/cmake/prism-config.cmake.in
+++ b/cmake/prism-config.cmake.in
@@ -1,5 +1,22 @@
 @PACKAGE_INIT@
 include("${CMAKE_CURRENT_LIST_DIR}/prism-targets.cmake")
+set(_prism_win_import_libs "@PRISM_WIN_STATIC_IMPORT_LIBS@")
+if(_prism_win_import_libs)
+  get_filename_component(_prism_imp_prefix "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  get_filename_component(_prism_imp_prefix "${_prism_imp_prefix}" PATH)
+  get_filename_component(_prism_imp_prefix "${_prism_imp_prefix}" PATH)
+  foreach(_imp IN LISTS _prism_win_import_libs)
+    if(NOT TARGET prism_import::${_imp})
+      add_library(prism_import::${_imp} UNKNOWN IMPORTED)
+      set_target_properties(prism_import::${_imp} PROPERTIES
+        IMPORTED_LOCATION "${_prism_imp_prefix}/lib/${_imp}.lib")
+      set_property(TARGET prism::prism APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES "prism_import::${_imp}")
+    endif()
+  endforeach()
+  unset(_prism_imp_prefix)
+endif()
+unset(_prism_win_import_libs)
 if(TARGET prism::_prism_lib)
   set_property(
     TARGET prism::_prism_lib


### PR DESCRIPTION
When Prism is built for windows, several import libraries (boy_pc_reader.lib, pc_talker.lib, zdsr.lib etc) - things from the defs folder are generated. When building as a DLL, this does not present any issue as everything is linked into a final package.

When building Prism as a static library, however, CMake does not deliver these import libraries as linkable artifacts to the user. They won't get installed (vcpkg_cmake_install), and they won't be linked in the Prism CMake target. This causes undefined symbol errors upon linking a final end product using the Prism static library when code in prism.lib tries to access, for example, the Speak() function from zdsr. For instance `prism.lib(zdsr.cpp.obj) : error LNK2001: unresolved external symbol __imp_Speak`

This PR causes the build to keep track of these generated import libraries and, only if the build is static, to both include them in the install list and to link them in the generated CMake target. When the diff this PR incapsolates is applied as a vcpkg overlay port patch, I am successfully able to include ethindp-prism as a vcpkg dep, build with a static triplet, and link a final output product. When building as shared, the generated import libraries are left entirely alone as before.

NOTE! I am beyond lousy with CMake syntax, so once I discovered the source of my prism linkage error, though with specific instruction and testing after the fact, I allowed CLAUDE to do the gruntwork here. Everything seems to work fine and the diff looks perfectly logical to me, but might be worth a careful extra look just encase. Not knowing the CMake language, I cannot improve this further - I just know it works perfectly as a VCPKG patch and thought to share the fix encase it's helpful either directly or otherwise.

Thanks for the great library!
