### PR TITLE
Fix exception escape in proton/wine

### DIFF
--- a/source/backends/onecore.cpp
+++ b/source/backends/onecore.cpp
@@ -150,14 +150,14 @@ public:
   }
 
   BackendResult<> initialize() override {
-    if (!ApiInformation::IsTypePresent(
-            _T("Windows.Media.SpeechSynthesis.SpeechSynthesizer")) ||
-        !ApiInformation::IsTypePresent(
-            _T("Windows.Media.Playback.MediaPlayer")))
-      return std::unexpected(BackendError::BackendNotAvailable);
-    if (synth || player)
-      return std::unexpected(BackendError::AlreadyInitialized);
     try {
+      if (!ApiInformation::IsTypePresent(
+              _T("Windows.Media.SpeechSynthesis.SpeechSynthesizer")) ||
+          !ApiInformation::IsTypePresent(
+              _T("Windows.Media.Playback.MediaPlayer")))
+        return std::unexpected(BackendError::BackendNotAvailable);
+      if (synth || player)
+        return std::unexpected(BackendError::AlreadyInitialized);
       synth = SpeechSynthesizer();
       synth.Options().AppendedSilence(SpeechAppendedSilence::Min);
       synth.Options().PunctuationSilence(SpeechPunctuationSilence::Min);


### PR DESCRIPTION
ApiInformation::IsTypePresent in the one core initializer ran outside the try-catch block. In proton/wine those functions threw E_NOTIMPL, which bubbled out of the initializer and could crash programs using prism. I simply moved the try opening to the beginning of the initializer to avoid this.

Note this may need testing, I don't use prism for windows much so haven't had a chance to test it heavily.