### PR TITLE
fix: resolve ZDSR backend delay-load failure on 32-bit x86

### DIFF
--- a/source/delayimp.cpp
+++ b/source/delayimp.cpp
@@ -979,11 +979,44 @@ static FARPROC WINAPI DelayLoadFailureHook(unsigned dliNotify,
                 pdli->szDll, pdli->dlp.dwOrdinal);
       return nullptr; // see below re: what this actually does
     }
+    // On x86, the delay-load table stores stdcall-decorated names (e.g.
+    // "InitTTS@12"), but the actual DLL may export undecorated names (e.g.
+    // "InitTTS"). Try GetProcAddress with the undecorated name first.
+#if defined(_M_IX86) || defined(__i386__)
+    if (pdli->dlp.fImportByName != 0) {
+      auto name = std::string_view(pdli->dlp.szProcName);
+      auto at = name.find('@');
+      if (at != std::string_view::npos) {
+        std::string undecorated(name.substr(0, at));
+        if (auto *real = GetProcAddress(pdli->hmodCur, undecorated.c_str())) {
+          log.info("recovered '{}!{}' via undecorated name", pdli->szDll,
+                   undecorated);
+          return real;
+        }
+      }
+    }
+#endif
     for (const auto &e : stubs) {
-      if (_stricmp(pdli->szDll, e.dll) == 0 &&
-          strcmp(pdli->dlp.szProcName, e.func) == 0) {
-        log.trace("substituting stub for '{}!{}'", pdli->szDll, e.func);
-        return e.stub;
+      if (_stricmp(pdli->szDll, e.dll) == 0) {
+#if defined(_M_IX86) || defined(__i386__)
+        auto procName = std::string_view(pdli->dlp.szProcName);
+        auto stubName = std::string_view(e.func);
+        auto procAt = procName.find('@');
+        auto stubAt = stubName.find('@');
+        if (procAt != std::string_view::npos)
+          procName = procName.substr(0, procAt);
+        if (stubAt != std::string_view::npos)
+          stubName = stubName.substr(0, stubAt);
+        if (procName == stubName) {
+          log.trace("substituting stub for '{}!{}'", pdli->szDll, e.func);
+          return e.stub;
+        }
+#else
+        if (strcmp(pdli->dlp.szProcName, e.func) == 0) {
+          log.trace("substituting stub for '{}!{}'", pdli->szDll, e.func);
+          return e.stub;
+        }
+#endif
       }
     }
     if (pdli->dlp.fImportByName != 0)


### PR DESCRIPTION
ZDSRAPI.dll (32-bit) exports undecorated function names (e.g. \InitTTS\), but the MSVC delay-load import table on x86 stores stdcall-decorated names (\InitTTS@12\). This causes \GetProcAddress\ to fail at runtime even when the DLL is loaded via the registry recovery path.

Additionally, the delay-load hook's stub comparison fails due to the same decoration mismatch, resulting in a null pointer return (crash/exception) when the DLL cannot be found at all.

## Changes

- source/delayimp.cpp: In \dliFailGetProc\, strip the \@N\ suffix from the function name before calling \GetProcAddress\, matching the DLL's actual export name
- source/delayimp.cpp: In the stub comparison loop on x86, strip \@N\ suffix from both the proc name and stub entries before comparing, ensuring graceful stub fallback when the DLL is absent

## Testing

- Built and tested on Windows x86 (32-bit) with ZDSR installed
- ZDSR backend initializes and functions correctly after the fix
- NVDA, SAPI5, OneCore backends unaffected