### PR TITLE
Winelibs: use the MS x64 ABI for exported bridge functions

### DIFF
--- a/winelibs/orca/bridge.c
+++ b/winelibs/orca/bridge.c
@@ -137,7 +137,7 @@ static GDBusConnection *open_private_session_bus(void) {
   return c;
 }
 
-bool prism_orca_available(void) {
+PRISM_WINELIB_ABI bool prism_orca_available(void) {
   GError *err = NULL;
   GDBusConnection *c = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &err);
   if (err) {
@@ -166,7 +166,7 @@ bool prism_orca_available(void) {
   return result;
 }
 
-bool prism_orca_create(PrismOrcaDBusInstance **out) {
+PRISM_WINELIB_ABI bool prism_orca_create(PrismOrcaDBusInstance **out) {
   if (!out) {
     return false;
   }
@@ -206,7 +206,7 @@ bool prism_orca_create(PrismOrcaDBusInstance **out) {
   return true;
 }
 
-void prism_orca_destroy(PrismOrcaDBusInstance *h) {
+PRISM_WINELIB_ABI void prism_orca_destroy(PrismOrcaDBusInstance *h) {
   if (!h) {
     return;
   }
@@ -217,7 +217,8 @@ void prism_orca_destroy(PrismOrcaDBusInstance *h) {
   free(h);
 }
 
-bool prism_orca_speak(PrismOrcaDBusInstance *h, const char *text) {
+PRISM_WINELIB_ABI bool prism_orca_speak(PrismOrcaDBusInstance *h,
+                                        const char *text) {
   if (!h || !text || !h->conn || !h->dialect) {
     return false;
   }
@@ -239,7 +240,7 @@ bool prism_orca_speak(PrismOrcaDBusInstance *h, const char *text) {
   return ok ? true : false;
 }
 
-bool prism_orca_stop(PrismOrcaDBusInstance *h) {
+PRISM_WINELIB_ABI bool prism_orca_stop(PrismOrcaDBusInstance *h) {
   if (!h || !h->conn || !h->dialect || !h->speech_path) {
     return false;
   }

--- a/winelibs/orca/bridge.h
+++ b/winelibs/orca/bridge.h
@@ -3,17 +3,25 @@
 #ifndef PRISM_ORCA_BRIDGE_H
 #define PRISM_ORCA_BRIDGE_H
 #include <stdbool.h>
+
+#if defined(__x86_64__)
+#define PRISM_WINELIB_ABI __attribute__((ms_abi))
+#else
+#define PRISM_WINELIB_ABI
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct PrismOrcaDBusInstance PrismOrcaDBusInstance;
 
-bool prism_orca_available(void);
-bool prism_orca_create(PrismOrcaDBusInstance **out);
-void prism_orca_destroy(PrismOrcaDBusInstance *h);
-bool prism_orca_speak(PrismOrcaDBusInstance *h, const char *text);
-bool prism_orca_stop(PrismOrcaDBusInstance *h);
+PRISM_WINELIB_ABI bool prism_orca_available(void);
+PRISM_WINELIB_ABI bool prism_orca_create(PrismOrcaDBusInstance **out);
+PRISM_WINELIB_ABI void prism_orca_destroy(PrismOrcaDBusInstance *h);
+PRISM_WINELIB_ABI bool prism_orca_speak(PrismOrcaDBusInstance *h,
+                                        const char *text);
+PRISM_WINELIB_ABI bool prism_orca_stop(PrismOrcaDBusInstance *h);
 
 #ifdef __cplusplus
 }

--- a/winelibs/speechd/bridge.cpp
+++ b/winelibs/speechd/bridge.cpp
@@ -21,7 +21,7 @@ struct Instance {
 
 struct PrismSpeechDispatcherInstance : Instance {};
 
-extern "C" bool prism_speechd_available(void) {
+extern "C" PRISM_WINELIB_ABI bool prism_speechd_available(void) {
   auto *addr = spd_get_default_address(nullptr);
   if (addr != nullptr) {
     bool available = false;
@@ -72,7 +72,8 @@ extern "C" bool prism_speechd_available(void) {
   return false;
 }
 
-extern "C" bool prism_speechd_create(PrismSpeechDispatcherInstance **out) {
+extern "C" PRISM_WINELIB_ABI bool
+prism_speechd_create(PrismSpeechDispatcherInstance **out) {
   if (!out)
     return false;
   *out = nullptr;
@@ -91,7 +92,8 @@ extern "C" bool prism_speechd_create(PrismSpeechDispatcherInstance **out) {
   return true;
 }
 
-extern "C" void prism_speechd_destroy(PrismSpeechDispatcherInstance *h) {
+extern "C" PRISM_WINELIB_ABI void
+prism_speechd_destroy(PrismSpeechDispatcherInstance *h) {
   if (!h)
     return;
   if (h->conn != nullptr) {
@@ -101,14 +103,15 @@ extern "C" void prism_speechd_destroy(PrismSpeechDispatcherInstance *h) {
   delete h;
 }
 
-extern "C" bool prism_speechd_speak(PrismSpeechDispatcherInstance *h,
-                                    const char *text) {
+extern "C" PRISM_WINELIB_ABI bool
+prism_speechd_speak(PrismSpeechDispatcherInstance *h, const char *text) {
   if (!h || !text || !h->conn)
     return false;
   return spd_say(h->conn, SPD_TEXT, text) >= 0;
 }
 
-extern "C" bool prism_speechd_stop(PrismSpeechDispatcherInstance *h) {
+extern "C" PRISM_WINELIB_ABI bool
+prism_speechd_stop(PrismSpeechDispatcherInstance *h) {
   if (!h || !h->conn)
     return false;
   return spd_stop(h->conn) == 0;

--- a/winelibs/speechd/bridge.h
+++ b/winelibs/speechd/bridge.h
@@ -3,17 +3,26 @@
 #ifndef prism_speechd_BRIDGE_H
 #define prism_speechd_BRIDGE_H
 #include <stdbool.h>
+
+#if defined(__x86_64__)
+#define PRISM_WINELIB_ABI __attribute__((ms_abi))
+#else
+#define PRISM_WINELIB_ABI
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct PrismSpeechDispatcherInstance PrismSpeechDispatcherInstance;
 
-bool prism_speechd_available(void);
-bool prism_speechd_create(PrismSpeechDispatcherInstance **out);
-void prism_speechd_destroy(PrismSpeechDispatcherInstance *h);
-bool prism_speechd_speak(PrismSpeechDispatcherInstance *h, const char *text);
-bool prism_speechd_stop(PrismSpeechDispatcherInstance *h);
+PRISM_WINELIB_ABI bool prism_speechd_available(void);
+PRISM_WINELIB_ABI bool
+prism_speechd_create(PrismSpeechDispatcherInstance **out);
+PRISM_WINELIB_ABI void prism_speechd_destroy(PrismSpeechDispatcherInstance *h);
+PRISM_WINELIB_ABI bool prism_speechd_speak(PrismSpeechDispatcherInstance *h,
+                                           const char *text);
+PRISM_WINELIB_ABI bool prism_speechd_stop(PrismSpeechDispatcherInstance *h);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Disclosure: created with the help of Claude Code. I myself am not familiar with how the win32 calling conventions work, but I've eyeballed the code and it doesn't appear to do anything nefarious, though I don't know if it should be gated only on x86_64 or if it'd make sense on aarch64 platforms too.

My goal was to get various game accessibility mods running in Proton, communicating with Orca. With this patch in place, and using the installer I'm building, I've successfully used this DLL with both Hades and Disco Elysium. Both now speak natively through Orca but didn't before.