### PR TITLE
AVSpeech: reuse one synthesizer in speak_to_memory to fix a teardown crash under rapid synthesis

### DIFF
--- a/source/backends/avspeech.cpp
+++ b/source/backends/avspeech.cpp
@@ -69,6 +69,9 @@ struct VoiceInfo {
 class AVSpeechBackend final : public TextToSpeechBackend {
 private:
   AVSpeechSynthesizer *synthesizer{nullptr};
+  // Reused across speak_to_memory calls: a per-utterance synthesizer's
+  // teardown races its queued TextToSpeech callbacks and crashes under load.
+  AVSpeechSynthesizer *memory_synthesizer{nullptr};
   std::atomic_flag initialized;
   std::atomic<float> volume{0.5F};
   std::atomic<float> pitch{0.5F};
@@ -115,6 +118,10 @@ public:
         if (synthesizer != nullptr) {
           [synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
           synthesizer = nil;
+        }
+        if (memory_synthesizer != nullptr) {
+          [memory_synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+          memory_synthesizer = nil;
         }
       });
     }
@@ -281,9 +288,12 @@ public:
           target_voice_id = voices[v_idx].identifier;
       }
       auto *acc = [[AVSpeechMemoryAccumulator alloc] init];
-      __block AVSpeechSynthesizer *mem_synth = nil;
       sync_on_main(^{
-        mem_synth = [[AVSpeechSynthesizer alloc] init];
+        if (memory_synthesizer == nullptr) {
+          memory_synthesizer = [[AVSpeechSynthesizer alloc] init];
+        } else if (memory_synthesizer.isSpeaking) {
+          [memory_synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
+        }
         AVSpeechUtterance *utterance =
             [AVSpeechUtterance speechUtteranceWithString:ns_text];
         utterance.volume = current_vol;
@@ -302,19 +312,20 @@ public:
               utterance.voice = v;
           }
         }
-        [mem_synth writeUtterance:utterance
-                 toBufferCallback:^(AVAudioBuffer *_Nonnull buffer) {
-                   if ([buffer isKindOfClass:[AVAudioPCMBuffer class]] == NO)
-                     return;
-                   auto *pcm = (AVAudioPCMBuffer *)buffer;
-                   if (pcm.frameLength == 0) {
-                     dispatch_semaphore_signal(acc.done_sema);
-                     return;
-                   }
-                   if (acc.captured_format == nullptr)
-                     acc.captured_format = pcm.format;
-                   [acc.buffers addObject:pcm];
-                 }];
+        [memory_synthesizer
+              writeUtterance:utterance
+            toBufferCallback:^(AVAudioBuffer *_Nonnull buffer) {
+              if ([buffer isKindOfClass:[AVAudioPCMBuffer class]] == NO)
+                return;
+              auto *pcm = (AVAudioPCMBuffer *)buffer;
+              if (pcm.frameLength == 0) {
+                dispatch_semaphore_signal(acc.done_sema);
+                return;
+              }
+              if (acc.captured_format == nullptr)
+                acc.captured_format = pcm.format;
+              [acc.buffers addObject:pcm];
+            }];
       });
       wait_for_semaphore_pumping_main(acc.done_sema, 60.0 * 5.0);
       if (acc.buffers.count == 0 || acc.captured_format == nil)

--- a/source/backends/avspeech.cpp
+++ b/source/backends/avspeech.cpp
@@ -289,7 +289,7 @@ public:
       sync_on_main(^{
         if (memory_synthesizer == nullptr) {
           memory_synthesizer = [[AVSpeechSynthesizer alloc] init];
-        } else if (memory_synthesizer.isSpeaking) {
+        } else if (memory_synthesizer.isSpeaking == YES) {
           [memory_synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
         }
         auto *mem_synth = memory_synthesizer;

--- a/source/backends/avspeech.cpp
+++ b/source/backends/avspeech.cpp
@@ -69,8 +69,6 @@ struct VoiceInfo {
 class AVSpeechBackend final : public TextToSpeechBackend {
 private:
   AVSpeechSynthesizer *synthesizer{nullptr};
-  // Reused across speak_to_memory calls: a per-utterance synthesizer's
-  // teardown races its queued TextToSpeech callbacks and crashes under load.
   AVSpeechSynthesizer *memory_synthesizer{nullptr};
   std::atomic_flag initialized;
   std::atomic<float> volume{0.5F};
@@ -294,6 +292,7 @@ public:
         } else if (memory_synthesizer.isSpeaking) {
           [memory_synthesizer stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
         }
+        auto *mem_synth = memory_synthesizer;
         AVSpeechUtterance *utterance =
             [AVSpeechUtterance speechUtteranceWithString:ns_text];
         utterance.volume = current_vol;
@@ -312,20 +311,19 @@ public:
               utterance.voice = v;
           }
         }
-        [memory_synthesizer
-              writeUtterance:utterance
-            toBufferCallback:^(AVAudioBuffer *_Nonnull buffer) {
-              if ([buffer isKindOfClass:[AVAudioPCMBuffer class]] == NO)
-                return;
-              auto *pcm = (AVAudioPCMBuffer *)buffer;
-              if (pcm.frameLength == 0) {
-                dispatch_semaphore_signal(acc.done_sema);
-                return;
-              }
-              if (acc.captured_format == nullptr)
-                acc.captured_format = pcm.format;
-              [acc.buffers addObject:pcm];
-            }];
+        [mem_synth writeUtterance:utterance
+                 toBufferCallback:^(AVAudioBuffer *_Nonnull buffer) {
+                   if ([buffer isKindOfClass:[AVAudioPCMBuffer class]] == NO)
+                     return;
+                   auto *pcm = (AVAudioPCMBuffer *)buffer;
+                   if (pcm.frameLength == 0) {
+                     dispatch_semaphore_signal(acc.done_sema);
+                     return;
+                   }
+                   if (acc.captured_format == nullptr)
+                     acc.captured_format = pcm.format;
+                   [acc.buffers addObject:pcm];
+                 }];
       });
       wait_for_semaphore_pumping_main(acc.done_sema, 60.0 * 5.0);
       if (acc.buffers.count == 0 || acc.captured_format == nil)


### PR DESCRIPTION
## Summary

`AVSpeechBackend::speak_to_memory` allocates a new `AVSpeechSynthesizer` for
every call and lets the calling thread drop the last reference when the call
returns. Destroying a synthesizer while Apple's TextToSpeech framework still
has callback blocks for it queued on the main dispatch queue is racy: the
teardown runs on the framework's AXSpeech thread, and a late callback block
then dereferences freed state and crashes the process (EXC_BAD_ACCESS,
KERN_INVALID_ADDRESS).

This is hard to hit with occasional synthesis, but a caller that synthesizes
many short utterances in quick succession — dozens of `speak_to_memory` calls
per minute, sustained — loses the race within minutes.

This PR makes the backend keep one long-lived synthesizer for memory
synthesis, mirroring what the class already does for the live `speak` path
(the `synthesizer` member). No API or behavior change otherwise.

## Crash evidence

Observed on macOS 26 in an x86_64 process running under Rosetta 2. The crash
report shows:

- Crashed thread (main): `EXC_BAD_ACCESS / KERN_INVALID_ADDRESS at 0x10`
  inside a `dispatch_call_block_and_release` block whose program counter is in
  `TextToSpeech.framework`.
- At the same moment, the `AXSpeech` thread is mid-teardown of TextToSpeech
  objects: a chain of `_objc_rootDealloc` / `object_cxxDestructFromClass`
  frames through TextToSpeech, including a Combine `CurrentValueSubject`
  deinit.
- The only in-process TTS user is the Prism AVSpeech backend's
  `speak_to_memory` path; every call created and destroyed one synthesizer.

I can attach the full .ips crash report if useful.

## Fix

- Add a `memory_synthesizer` member, created lazily on the main thread on the
  first `speak_to_memory` call and reused for the life of the backend, so no
  synthesizer teardown ever runs while the framework may still hold callbacks.
- If a previous utterance somehow left it speaking (e.g. the caller's wait
  timed out), stop it with `AVSpeechBoundaryImmediate` before writing the next
  utterance.
- Release it in the destructor alongside the existing `synthesizer` member.

One file changed, `source/backends/avspeech.cpp`; formatted with the repo's
.clang-format. Most of the diff's line count is the `writeUtterance:` call
body re-indenting under the renamed receiver.

## Why this is safe

- `speak_to_memory` already serializes per backend instance in practice (the
  caller waits on the accumulator semaphore before issuing the next call), so
  the reused synthesizer never sees overlapping write requests, and the
  stop-before-reuse guard covers the timeout path.
- The reused object holds no per-utterance state: voice, rate, pitch, and
  volume are set on each `AVSpeechUtterance`, not on the synthesizer.
- Memory cost is one retained synthesizer per backend instance, in exchange
  for dropping a full registration + teardown cycle per utterance.

## Testing

- Built for x86_64 macOS with the project CMake (gdextension/tests/demos off);
  compiles with no new warnings.
- Deployed in the application where the crash was found, which drives this
  exact path with rapid short-utterance synthesis. Before the change, the
  crash was reproducible under sustained use with the signature above; with
  the patch applied, the same workload runs without crashes or audio
  regressions.
