### PR TITLE
Fix invalid const-qualified function pointer in delayimp.cpp (breaks x86 clang-cl build)

### DIFF
--- a/source/delayimp.cpp
+++ b/source/delayimp.cpp
@@ -987,7 +987,7 @@ static FARPROC WINAPI DelayLoadFailureHook(unsigned dliNotify,
       const auto at = name.find('@');
       if (at != std::string_view::npos) {
         const std::string undecorated(name.substr(0, at));
-        if (auto const *real =
+        if (auto *const real =
                 GetProcAddress(pdli->hmodCur, undecorated.c_str());
             real != nullptr) {
           log.info("recovered '{}!{}' via undecorated name", pdli->szDll,


### PR DESCRIPTION
## Summary
- `GetProcAddress` returns `FARPROC` (a function pointer). The line
  `if (auto const *real = GetProcAddress(...); real != nullptr)` in the
  `#if defined(_M_IX86) || defined(__i386__)` branch of
  `DelayLoadFailureHook` deduces `real` as a pointer to a
  const-qualified *function type*, which isn't a meaningful
  declaration.
- clang-cl rejects this outright when targeting x86 (`-m32`):
  ```
  error: variable 'real' with type 'const auto *' has incompatible
  initializer of type 'FARPROC' (aka 'int (*)() __attribute__((stdcall)))')
  ```
- This branch is only compiled for `_M_IX86`/`__i386__`, and the
  project's own `build-windows.yml` matrix only builds x64/arm64, so
  the build break was never caught by CI.
- Every other raw pointer in this file (e.g. the `LoadLibrary` results
  a few lines above, `auto *const h = ...`) uses `auto *const` — a
  non-reassignable pointer to non-const data. That's almost certainly
  what was intended here too; `real` is never reassigned in this
  scope. Switching to that form fixes the x86 clang-cl build without
  changing behavior (MSVC accepted the original spelling as a
  non-conforming extension).

## Test plan
- [x] Build-verified: a downstream project (QQMusicEasier) builds this
      file with `clang-cl -m32` (`-DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS="-m32 /EHsc"`,
      Ninja, Release, shared) as part of its CI. With this one-line fix
      applied, that CI run compiles and links `prism.dll` successfully:
      https://github.com/TomJoey/QQMusicEasier/actions/runs/31920480814
      (previous run without the fix failed with the exact error above:
      https://github.com/TomJoey/QQMusicEasier/actions/runs/31920099844)
- [ ] This repo doesn't currently build x86 in CI, so this path isn't
      covered automatically — happy to add an x86 job if useful.