### PR TITLE
Windows: Keep ZDSR DLL loaded during shutdown

### DIFF
--- a/source/prism.cpp
+++ b/source/prism.cpp
@@ -169,12 +169,10 @@ PRISM_API void PRISM_CALL prism_shutdown(PrismContext *ctx) {
 #endif
   delete ctx;
 #ifdef _WIN32
-  (void)__FUnloadDelayLoadedDLL2("ZDSRAPI.dll");
   (void)__FUnloadDelayLoadedDLL2("byctrl.dll");
   (void)__FUnloadDelayLoadedDLL2("PCTKUSR.dll");
   (void)__FUnloadDelayLoadedDLL2("prism_orca_bridge.dll");
   (void)__FUnloadDelayLoadedDLL2("prism_speech_dispatcher_bridge.dll");
-  (void)__FUnloadDelayLoadedDLL2("ZDSRAPI_x64.dll");
   (void)__FUnloadDelayLoadedDLL2("byctrl-x64.dll");
 #endif
 }


### PR DESCRIPTION
ZDSR can leave asynchronous work running after Prism releases its backend. `prism_shutdown` currently unloads `ZDSRAPI.dll`/`ZDSRAPI_x64.dll`, which intermittently leaves the host executing code from an unloaded module.

Windows Error Reporting captured `ZDSRAPI_x64.dll_unloaded` with `0xc0000005` at the same offset across separate runs. An automated application exit loop reproduced this in 3/5 runs with v0.18.2. Keeping the ZDSR delay-loaded DLL resident until process termination produced 30/30 clean exits in Debug and Release builds.

Prism still releases the backend, context, and availability enumerator normally. Other delay-loaded backends are unchanged.

A CI regression test is not included because reproduction requires the proprietary ZDSR installation and is timing-dependent.

Fixes #109

AI assistance was used for crash analysis and drafting. I reproduced the issue, reviewed the change, and verified the results.